### PR TITLE
Add conversion for type arrays with 'null'

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,107 @@ components:
           - '1.0.0'
 ```
 
+### Convert type arrays to nullable
+
+If a schema has a type array of exactly two values, and one of them
+is the string `'null'`, the type is converted to the non-null string item,
+and `nullable: true` added to the schema.
+
+For example:
+
+```yaml
+    myResponse:
+      title: My Response
+      description: Response from an API operation
+      type: [ object, 'null' ]
+      allOf:
+        ...
+```
+
+becomes
+
+```yaml
+    myResponse:
+      title: My Response
+      description: Response from an API operation
+      type: object
+      nullable: true
+      allOf:
+        ...
+```
+
+and
+
+```yaml
+    myResponse:
+      title: My Response
+      description: Response from an API operation
+      type: arrray
+      items:
+        type: [ 'string', 'null' ]
+        ...
+```
+
+becomes
+
+```yaml
+    myResponse:
+      title: My Response
+      description: Response from an API operation
+      type: arrray
+      items:
+        type: string
+        nullable: true
+        ...
+```
+
+This transformation does not handle more complex `type` array
+scenarios such as
+
+```yaml
+   type: [ number, string, boolean, 'null']
+```
+
+To support that, the schema would need to be recast using `oneOf`,
+but this is not trivial do to other schema attributes that may
+be possible (`properties`, `allOf` etc.)
+
+(Contributions welcome.)
+
+### Remove `unevaluatedProperties`
+
+The tool removes the `unevaluatedProperties` value, introduced in later
+versions of JSON Schema,
+as this is not supported in OAS 3.0 JSON Schema Draft 7
+used in OAS 3.0.
+
+```yaml
+    myResponse:
+      title: My Response
+      description: Response from an API operation
+      type: object
+      unevaluatedProperties: false
+      allOf:
+        ...
+```
+
+becomes
+
+```yaml
+    myResponse:
+      title: My Response
+      description: Response from an API operation
+      type: object
+      unevaluatedProperties: false
+      allOf:
+        ...
+```
+
+### Remove schema `$id` and `$schema`
+
+The tool removes any `$id` or `$schema` keywords that may appear
+inside schema objects.
+
 ## Unsupported down conversions
 
 * `openapi-down-convert` does not convert `exclusiveMinimum` and `exclusiveMaximum`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiture/openapi-down-convert",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiture/openapi-down-convert",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Tool to down convert OpenAPI 3.1 to OpenAPI 3.0",
   "main": "lib/src/index.js",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,9 @@ async function main(args: string[] = process.argv) {
       const format = outputFileName.endsWith('json') ? 'json' : 'yaml';
       const text = format === 'yaml' ? yaml.dump(resolved) : JSON.stringify(resolved, null, 2);
       const outDir = path.dirname(outputFileName);
-      fs.mkdirSync(outDir);
+      if (!fs.existsSync(outDir)) {
+        fs.mkdirSync(outDir, {recursive: true});
+      }
       fs.writeFileSync(outputFileName, text, 'utf8');
     } else {
       const format = sourceFileName.endsWith('json') ? 'json' : 'yaml';


### PR DESCRIPTION
Remove keywords not supported with OAS 3.0:
  - $id
  - $schema
  - unevaluatedProperties

See README.md for details