### PR TITLE
Add converter for oneOf/anyOf with nullable types

### DIFF
--- a/src/RefVisitor.ts
+++ b/src/RefVisitor.ts
@@ -126,3 +126,20 @@ export function walkObject(node: object, objectCallback: ObjectVisitor): JsonNod
     return array;
   }
 }
+
+/**
+ * Loads the schema/component located at $ref
+ */
+export function getRefSchema(node: object, ref: RefObject) {
+  const propertyName = ref.$ref.split('/').reverse()[0];
+  if (node.hasOwnProperty('components')) {
+    const components = node['components'];
+    if (components != null && typeof components === 'object' && components.hasOwnProperty('schemas')) {
+      const schemas = components['schemas'];
+      if (schemas.hasOwnProperty(propertyName)) {
+        return schemas[propertyName];
+      }
+    }
+  }
+  return null;
+}

--- a/test/converter.spec.ts
+++ b/test/converter.spec.ts
@@ -355,7 +355,6 @@ describe('resolver test suite', () => {
     done();
   });
 
-
   test('Remove patternProperties keywords', (done) => {
     const input = {
       openapi: '3.1.0',
@@ -364,12 +363,12 @@ describe('resolver test suite', () => {
           a: {
             type: 'object',
             properties: {
-                  s: {
-                    type: 'string',
-                  },
+              s: {
+                type: 'string',
+              },
             },
             patternProperties: {
-            "^[a-z{2}-[A-Z]{2,3}]$": {
+              '^[a-z{2}-[A-Z]{2,3}]$': {
                 type: 'object',
                 unevaluatedProperties: false,
                 properties: {
@@ -416,7 +415,7 @@ describe('resolver test suite', () => {
               b: {
                 type: 'string',
                 contentMediaType: 'application/pdf',
-                maxLength: 5000000
+                maxLength: 5000000,
               },
             },
           },
@@ -432,7 +431,7 @@ describe('resolver test suite', () => {
             properties: {
               b: {
                 type: 'string',
-                maxLength: 5000000
+                maxLength: 5000000,
               },
             },
           },
@@ -445,35 +444,34 @@ describe('resolver test suite', () => {
     done();
   });
 
-
-   test('Remove webhooks object', (done) => {
+  test('Remove webhooks object', (done) => {
     const input = {
       openapi: '3.1.0',
-        webhooks: {
-          newThing: {
-            post: {
-              requestBody: {
-                description: 'Information about a new thing in the system',
-                content: {
-                  'application/json': {
-                    schema: {
-                      $ref: '#/components/schemas/newThing'
-                    }
-                  }
-                }
+      webhooks: {
+        newThing: {
+          post: {
+            requestBody: {
+              description: 'Information about a new thing in the system',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/newThing',
+                  },
+                },
               },
-              responses: {
-                200: {
-                  description: 'Return a 200 status to indicate that the data was received successfully'
-                }
-              }
-            }
-          }
-        }
+            },
+            responses: {
+              200: {
+                description: 'Return a 200 status to indicate that the data was received successfully',
+              },
+            },
+          },
+        },
+      },
     };
 
     const expected = {
-      openapi: '3.0.3'
+      openapi: '3.0.3',
     };
 
     const converter = new Converter(input, { verbose: true });
@@ -644,6 +642,110 @@ describe('resolver test suite', () => {
     done();
   });
 
+  test('Convert anyOf with null type', (done) => {
+    const input = {
+      components: {
+        schemas: {
+          a: {
+            anyOf: [
+              {
+                $ref: '#/components/b',
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+          b: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const expected = {
+      openapi: '3.0.3',
+      components: {
+        schemas: {
+          a: {
+            anyOf: [
+              {
+                $ref: '#/components/b',
+              },
+            ],
+            type: 'string',
+            nullable: true,
+          },
+          b: {
+            type: 'string',
+          },
+        },
+      },
+    };
+
+    const converter = new Converter(input, { verbose: true });
+    const converted: any = converter.convert();
+    expect(converted).toEqual(expected);
+    done();
+  });
+
+  test('Convert oneOf with null type', (done) => {
+    const input = {
+      components: {
+        schemas: {
+          a: {
+            oneOf: [
+              {
+                $ref: '#/components/b',
+              },
+              {
+                $ref: '#/components/c',
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+          b: {
+            type: 'string',
+          },
+          c: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const expected = {
+      openapi: '3.0.3',
+      components: {
+        schemas: {
+          a: {
+            oneOf: [
+              {
+                $ref: '#/components/b',
+              },
+              {
+                $ref: '#/components/c',
+              },
+            ],
+            type: 'string',
+            nullable: true,
+          },
+          b: {
+            type: 'string',
+          },
+          c: {
+            type: 'string',
+          },
+        },
+      },
+    };
+
+    const converter = new Converter(input, { verbose: true });
+    const converted: any = converter.convert();
+    expect(converted).toEqual(expected);
+    done();
+  });
+
   test('Convert const to enum', (done) => {
     const input = {
       components: {
@@ -793,11 +895,11 @@ test('binary encoded data with existing binary format', (done) => {
   const converter = new Converter(input);
   let caught = false;
   try {
-      converter.convert();
+    converter.convert();
   } catch (e) {
     caught = true;
   }
-  expect(caught).toBeTruthy()
+  expect(caught).toBeTruthy();
   // TODO how to check that Converter logged a specific note?
   done();
 });
@@ -871,7 +973,7 @@ test('contentMediaType with existing binary format', (done) => {
         binaryEncodedDataWithExistingBinaryFormat: {
           type: 'string',
           contentMediaType: 'application/octet-stream',
-          format: 'binary'
+          format: 'binary',
         },
       },
     },
@@ -893,7 +995,6 @@ test('contentMediaType with existing binary format', (done) => {
   // TODO how to check that Converter logged to console.warn ?
   done();
 });
-
 
 test('contentMediaType with no existing format', (done) => {
   const input = {
@@ -933,21 +1034,20 @@ test('contentMediaType with existing unexpected format', (done) => {
         binaryEncodedDataWithExistingBinaryFormat: {
           type: 'string',
           contentMediaType: 'application/octet-stream',
-          format: 'byte'
+          format: 'byte',
         },
       },
     },
   };
 
-   const converter = new Converter(input);
-   let caught = false;
-   try {
-     converter.convert();
-   } catch (e) {
-     caught = true;
-   }
-   expect(caught).toBeTruthy();
+  const converter = new Converter(input);
+  let caught = false;
+  try {
+    converter.convert();
+  } catch (e) {
+    caught = true;
+  }
+  expect(caught).toBeTruthy();
   // TODO how to check that Converter logged to console.warn ?
   done();
 });
-


### PR DESCRIPTION
Resolves #23 - I ended up finding some time this weekend to work on this.


This change allows for the conversion of anyOf/oneOf arrays with $ref/obj and a `type: "null"`, which is a common way to do a type union in 3.1.0 to allow for a type to be a $ref, but also nullable. I've tested it on my own rather beefy spec (250+ endpoints and hundreds of types) with zero changes and it passed typecheck.  I recently upgraded my spec to 3.1.0 and the conversion tools used by this project were not able to accurately convert the 3.1.0 spec. 

Hopefully this is a good enough addition to add, it certainly suits my purposes. I can understand if it should be behind a flag though. Let me know if there are any other situations I may have missed.

Thanks!
